### PR TITLE
test: add stat tracker tests, update team stat tests, revise head to …

### DIFF
--- a/lib/season_stats.rb
+++ b/lib/season_stats.rb
@@ -1,7 +1,9 @@
 require_relative 'classes'
+require_relative 'team_module'
+
 
 class SeasonStats < Classes
-
+  include SeasonTeams
   def initialize(locations)
     super
   end
@@ -57,11 +59,6 @@ class SeasonStats < Classes
     end
     team_id
   end
-
-  def convert_id_to_teamname(id_string)
-    team = @teams.select{|team|team.team_id == id_string}
-    team[0].teamname
-  end
   #Helper method for most/least accurate team   
   def gather_goals_info(season_string)
     infohash = Hash.new(0)
@@ -75,13 +72,7 @@ class SeasonStats < Classes
   end
   #Helper method for most/least accurate team
   def gather_shots_info(season_string)
-    valid_game_ids = []
-    @games.each do |game|
-      if game.season == season_string
-        valid_game_ids << game.id
-      end
-    end
-
+    valid_game_ids = find_season_games(season_string)
     infohash = Hash.new(0)
     @game_teams.each do |game|
       if valid_game_ids.include?(game.game_id)
@@ -110,16 +101,6 @@ class SeasonStats < Classes
     array = sort_by_accuracy(season_string)
     team_id = array.last[0]
     convert_id_to_teamname(team_id)
-  end
-
-  def find_season_games(season_string)
-    valid_game_ids = []
-    @games.find_all do |game|
-      if game.season == season_string
-        valid_game_ids << game.id
-      end
-    end
-    valid_game_ids
   end
 
   def create_coach_season_record(season_string)

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -134,8 +134,8 @@ class StatTracker
     @team_stats.most_goals_scored(team_id)
   end
 
-  def least_goals_scored(team_id)
-    @team_stats.least_goals_scored(team_id)
+  def fewest_goals_scored(team_id)
+    @team_stats.fewest_goals_scored(team_id)
   end
 
   def favorite_opponent(team_id)

--- a/lib/team_module.rb
+++ b/lib/team_module.rb
@@ -1,0 +1,18 @@
+module SeasonTeams
+  
+
+  def convert_id_to_teamname(id_string)
+    team = @teams.select{|team|team.team_id == id_string}
+    team[0].teamname
+  end
+
+  def find_season_games(season_string)
+    valid_game_ids = []
+    @games.find_all do |game|
+      if game.season == season_string
+        valid_game_ids << game.id
+      end
+    end
+    valid_game_ids
+  end
+end

--- a/lib/team_stats.rb
+++ b/lib/team_stats.rb
@@ -1,6 +1,8 @@
 require_relative 'classes'
+require_relative 'team_module'
 
 class TeamStats < Classes
+  include SeasonTeams
   def initialize(locations)
     super
     @seasons = ["20122013", "20132014", "20142015", "20152016", "20162017", "20172018"]
@@ -143,7 +145,7 @@ class TeamStats < Classes
     @goals_scored.sort[-1]
   end
 
-  def least_goals_scored(team_id)
+  def fewest_goals_scored(team_id)
     most_goals_scored(team_id)
     @goals_scored.sort[0]
   end
@@ -197,7 +199,10 @@ class TeamStats < Classes
 
   def head_to_head(team_id)
     favorite_opponent(team_id)
-    @win_loss_by_team
+    @win_loss_by_team.each do |k, v|
+      k = convert_id_to_teamname(k)
+    end
+    @win_loss_by_team.transform_keys{|k| convert_id_to_teamname(k)}
   end
 
   def seasonal_summary(team_id)

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -123,5 +123,65 @@ RSpec.describe StatTracker do
 
       expect(@stat_tracker.average_win_percentage('6')).to eq(0.49)
     end
+
+    it 'can return fewest and most goals for a specific team' do
+
+      expect(@stat_tracker.most_goals_scored('18')).to eq(7)
+      expect(@stat_tracker.fewest_goals_scored('18')).to eq(0)
+    end
+
+    it 'can return a teams favorite opponent' do
+
+      expect(@stat_tracker.favorite_opponent('18')).to eq('DC United')
+    end
+
+    it 'can show a teams rival' do 
+
+      expect(@stat_tracker.rival('18')).to eq('Houston Dash').or(eq('LA Galaxy'))
+    end
+
+    it 'can show biggest blowout + worst loss for a specific team' do
+
+      expect(@stat_tracker.biggest_blowout('18')).to eq(5)
+      expect(@stat_tracker.worst_loss('18')).to eq(-4)
+    end
+
+    it 'can show head to head with each other team' do
+      expected = {
+        "Philadelphia Union"=>0.4411764705882353,
+        "Portland Thorns FC"=>0.45161290322580644,
+        "Vancouver Whitecaps FC"=>0.4375,
+        "New England Revolution"=>0.47368421052631576,
+        "Atlanta United"=>0.5,
+        "Orlando Pride"=>0.4666666666666667,
+        "New York Red Bulls"=>0.4,
+        "Montreal Impact"=>0.3333333333333333,
+        "Portland Timbers"=>0.3,
+        "Chicago Red Stars"=>0.48148148148148145,
+        "Toronto FC"=>0.3333333333333333,
+        "Los Angeles FC"=>0.44,
+        "Real Salt Lake"=>0.41935483870967744,
+        "Sporting Kansas City"=>0.25,
+        "Seattle Sounders FC"=>0.5,
+        "Utah Royals FC"=>0.6,
+        "DC United"=>0.8,
+        "Washington Spirit FC"=>0.6666666666666666,
+        "Houston Dynamo"=>0.4,
+        "North Carolina Courage"=>0.2,
+        "New York City FC"=>0.6,
+        "FC Cincinnati"=>0.3888888888888889,
+        "FC Dallas"=>0.4,
+        "Sky Blue FC"=>0.3,
+        "Orlando City SC"=>0.37037037037037035,
+        "San Jose Earthquakes"=>0.3333333333333333,
+        "LA Galaxy"=>0.2857142857142857,
+        "Columbus Crew SC"=>0.5,
+        "Chicago Fire"=>0.3,
+        "Reign FC"=>0.3333333333333333,
+        "Houston Dash"=>0.1
+      }
+
+      expect(@stat_tracker.head_to_head('18')).to eq(expected)
+    end
   end
 end

--- a/spec/team_stats_spec.rb
+++ b/spec/team_stats_spec.rb
@@ -42,8 +42,8 @@ describe TeamStats do
     expect(stat_tracker.team_stats.most_goals_scored("18")).to eq(7)
   end
 
-  it "can show the least goals scored for a team" do
-    expect(stat_tracker.team_stats.least_goals_scored("18")).to eq(0)
+  it "can show the fewest goals scored for a team" do
+    expect(stat_tracker.team_stats.fewest_goals_scored("18")).to eq(0)
   end
 
   it "can show favorite_opponent" do
@@ -63,37 +63,37 @@ describe TeamStats do
   end
 
   it 'can show head to head' do
-    expect(stat_tracker.team_stats.head_to_head("18")).to eq({"19"=>0.4411764705882353,
-                                                              "52"=>0.45161290322580644,
-                                                              "21"=>0.4375,
-                                                              "16"=>0.47368421052631576,
-                                                              "1"=>0.5,
-                                                              "29"=>0.4666666666666667,
-                                                              "8"=>0.4,
-                                                              "23"=>0.3333333333333333,
-                                                              "15"=>0.3,
-                                                              "25"=>0.48148148148148145,
-                                                              "20"=>0.3333333333333333,
-                                                              "28"=>0.44,
-                                                              "24"=>0.41935483870967744,
-                                                              "5"=>0.25,
-                                                              "2"=>0.5,
-                                                              "7"=>0.6,
-                                                              "14"=>0.8,
-                                                              "22"=>0.6666666666666666,
-                                                              "3"=>0.4,
-                                                              "10"=>0.2,
-                                                              "9"=>0.6,
-                                                              "26"=>0.3888888888888889,
-                                                              "6"=>0.4,
-                                                              "12"=>0.3,
-                                                              "30"=>0.37037037037037035,
-                                                              "27"=>0.3333333333333333,
-                                                              "17"=>0.2857142857142857,
-                                                              "53"=>0.5,
-                                                              "4"=>0.3,
-                                                              "54"=>0.3333333333333333,
-                                                              "13"=>0.1
+    expect(stat_tracker.team_stats.head_to_head("18")).to eq({"Philadelphia Union"=>0.4411764705882353,
+                                                              "Portland Thorns FC"=>0.45161290322580644,
+                                                              "Vancouver Whitecaps FC"=>0.4375,
+                                                              "New England Revolution"=>0.47368421052631576,
+                                                              "Atlanta United"=>0.5,
+                                                              "Orlando Pride"=>0.4666666666666667,
+                                                              "New York Red Bulls"=>0.4,
+                                                              "Montreal Impact"=>0.3333333333333333,
+                                                              "Portland Timbers"=>0.3,
+                                                              "Chicago Red Stars"=>0.48148148148148145,
+                                                              "Toronto FC"=>0.3333333333333333,
+                                                              "Los Angeles FC"=>0.44,
+                                                              "Real Salt Lake"=>0.41935483870967744,
+                                                              "Sporting Kansas City"=>0.25,
+                                                              "Seattle Sounders FC"=>0.5,
+                                                              "Utah Royals FC"=>0.6,
+                                                              "DC United"=>0.8,
+                                                              "Washington Spirit FC"=>0.6666666666666666,
+                                                              "Houston Dynamo"=>0.4,
+                                                              "North Carolina Courage"=>0.2,
+                                                              "New York City FC"=>0.6,
+                                                              "FC Cincinnati"=>0.3888888888888889,
+                                                              "FC Dallas"=>0.4,
+                                                              "Sky Blue FC"=>0.3,
+                                                              "Orlando City SC"=>0.37037037037037035,
+                                                              "San Jose Earthquakes"=>0.3333333333333333,
+                                                              "LA Galaxy"=>0.2857142857142857,
+                                                              "Columbus Crew SC"=>0.5,
+                                                              "Chicago Fire"=>0.3,
+                                                              "Reign FC"=>0.3333333333333333,
+                                                              "Houston Dash"=>0.1
                                                               })
   end
 


### PR DESCRIPTION
…head to return team names

used the .transform_keys to get head_to_head to return team names instead of team IDs, also incorporated a module for name conversion as well as finding season-relevant game IDs to work with, cutting down on clutter in some of our stat classes